### PR TITLE
s/set_terminal_title/set_iterm_title/

### DIFF
--- a/iterm2_helpers.sh
+++ b/iterm2_helpers.sh
@@ -46,7 +46,7 @@ fi
 alias title='set_iterm_title'
 
 function titlepwd() {
-  set_terminal_title `pwd`
+  set_iterm_title `pwd`
 }
 
 function tab_maroon { title "$1"; tab_color 128 0 0; }


### PR DESCRIPTION
Fixes: 
~ ∙ titlepwd
bash: set_terminal_title: command not found
