### PR TITLE
add -- to terminate basename option (in case -bash starts with -)

### DIFF
--- a/iterm2_helpers.sh
+++ b/iterm2_helpers.sh
@@ -21,14 +21,14 @@ title_help0()
 {
 echo "ERROR: No argument provided."
 echo "Usage:"
-echo "  `basename $0` \"title\" to provide a new Terminal title."
+echo "  `basename -- $0` \"title\" to provide a new Terminal title."
 }
 
 title_help2()
 {
 echo "ERROR: Too many arguments provided."
 echo "Usage:"
-echo "  `basename $0` \"title\" to provide a new Terminal title."
+echo "  `basename -- $0` \"title\" to provide a new Terminal title."
 }
 
 function set_iterm_title() {


### PR DESCRIPTION
```
TDWONG-M-V08D:~$ cd Workspace/GitHub/iTerm2-finna-be-octo-hipster/
TDWONG-M-V08D:iTerm2-finna-be-octo-hipster$ echo $0
-bash
TDWONG-M-V08D:iTerm2-finna-be-octo-hipster$ title
-bash: title: command not found
TDWONG-M-V08D:iTerm2-finna-be-octo-hipster$ . iterm2_helpers.sh
TDWONG-M-V08D:iTerm2-finna-be-octo-hipster$ title
ERROR: No argument provided.
Usage:
  -bash "title" to provide a new Terminal title.
TDWONG-M-V08D:iTerm2-finna-be-octo-hipster$
```

If the $0 starts with a dash (see above case), the title_help0() and title_help2() failed in providing the usage message as the basename command is confused by the leading dash.

The solution is to add '--' to end basename option list.
